### PR TITLE
Add default PR template

### DIFF
--- a/pull_request_template.md
+++ b/pull_request_template.md
@@ -1,0 +1,21 @@
+## Problem
+
+Describe the purpose of this change. What problem is being solved and why?
+
+## Solution
+
+Describe the approach you took. Link to any relevant bugs, issues, docs, or other resources.
+
+## Type of Change
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] This change requires a documentation update
+- [ ] Infrastructure change (CI configs, etc)
+- [ ] Non-code change (docs, etc)
+- [ ] None of the above: (explain here)
+
+## Test Plan
+
+Describe specific steps for validating this change.


### PR DESCRIPTION
## Problem

Some PRs would be easier to review with additional context shared in the description. PRs on our many open source repositories vary widely in quality. Additional context is very helpful also when investigating bugs in case something needs to be rolled back.

## Solution

Add a simple PR [template](https://docs.github.com/en/communities/using-templates-to-encourage-useful-issues-and-pull-requests/creating-a-pull-request-template-for-your-repository) to guide people toward including more information about their proposed changes.

This is also useful context for reviewers of internal changes.

If you'd like to specify something different for your repository, placing a repo-specific template into the `.github` dir of your repository will have precedence over this one.

## Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [x] Non-code change (docs, CI config, etc)
- [ ] None of the above: (explain here)

## Test Plan

Open some PRs, see the text field is populated with this template.