### PR TITLE
profile README: rename "AI assistants" to "AI coding tools"

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -33,7 +33,7 @@
 
 - Official clients: [Python](https://github.com/pinecone-io/python-sdk), [TypeScript](https://github.com/pinecone-io/pinecone-ts-client), [Go](https://github.com/pinecone-io/go-pinecone), [Java](https://github.com/pinecone-io/pinecone-java-client)
 - Examples: [notebooks](https://github.com/pinecone-io/examples) and [sample apps](https://github.com/pinecone-io/sample-apps)
-- AI assistants: [AI coding tools](https://docs.pinecone.io/guides/get-started/ai-coding-tools) and [Pinecone MCP](https://github.com/pinecone-io/pinecone-mcp) 
+- AI coding tools: [setup guide](https://docs.pinecone.io/guides/get-started/ai-coding-tools) and [Pinecone MCP](https://github.com/pinecone-io/pinecone-mcp)
 - Infrastructure as code: [Terraform provider](https://github.com/pinecone-io/terraform-provider-pinecone)
 
 New to vector databases? Start with the [quickstart](https://docs.pinecone.io/guides/get-started/quickstart).


### PR DESCRIPTION
Follow-up to #6. Renames the third "Start building" bullet from "AI assistants" to "AI coding tools" so the label matches where it links (the AI coding tools guide plus the Pinecone MCP) and does not read as the Pinecone Assistant product.

Picks up Jenna's suggestion on the profile README thread.

Made with [Cursor](https://cursor.com)